### PR TITLE
DBの設計(テーブルの追加)/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -44,13 +44,13 @@ Things you may want to cover:
 ### Association
 - has_many :groups_users
 - has_many :groups,through: groups_users
-- has_many :massages
+- has_many :messages
 
 ## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false, unique: true|
+|name|string|null: false, unique: true|
 
 ### Association
 - has_many :groups_users
@@ -63,8 +63,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text|
 |image|string|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ Things you may want to cover:
 - has_many :groups_users
 - has_many :groups,through: groups_users
 - has_many :massages
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false, unique: true|
+
+### Association
+- has_many :groups_users
+- has_many :users,through: groups_users
+- has_many :messages

--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ Things you may want to cover:
 - has_many :groups_users
 - has_many :users,through: groups_users
 - has_many :messages
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|
+|image|string|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false, add_index: true|
+|name|string|null: false, index: true|
 |email|string|null: false, unique: true|
 
 ### Association
 - has_many :groups_users
-- has_many :groups,through: groups_users
+- has_many :groups,through: :groups_users
 - has_many :messages
 
 ## groupsテーブル
@@ -54,7 +54,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :groups_users
-- has_many :users,through: groups_users
+- has_many :users,through: :groups_users
 - has_many :messages
 
 ## messagesテーブル

--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ Things you may want to cover:
 ### Association
 - belongs_to :group
 - belongs_to :user
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, add_index: true|
+|email|string|null: false, unique: true|
+
+### Association
+- has_many :groups_users
+- has_many :groups,through: groups_users
+- has_many :massages


### PR DESCRIPTION
#What
chat-spaceの実装にあたり、基礎となるデータベースの設計準備を行う目的。

1/ groups_usersテーブル（グループとユーザーの中間テーブル）
・ユーザーID　・グループID
2/usersテーブル（ユーザーの登録に関するテーブル）
・名前(ニックネーム)　・登録されるメールアドレス
3/groupsテーブル（チャットグループに関するテーブル）
・グループ名
4/messagesテーブル（チャットの投稿に関するテーブル）
・投稿テキスト　・投稿画像　・投稿者名　・グループ名

#Why
実装に入る前段階準備として、機能の洗い出しと必要となるデータベースを確認・作成するため。