### PR TITLE
chat-spaceフロント画面の実装

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -1,0 +1,179 @@
+* {
+  box-sizing: border-box;
+}
+
+$white-color: #fff;
+$btn-color: #38aef0;
+//サイド画面
+.chat-side {
+  float: left;
+  width: 300px;
+  height: 100vh;
+  color: $white-color;
+  //サイド画面ヘッダー
+  &__header {
+    display: flex;
+    height: 100px;
+    background-color: #253141;
+    align-items: center;
+    &__box {
+      height: 20px;
+      width: 260px;
+      margin: 0 20px;
+      &__user-name {
+        float: left;
+        font-size: 16px;
+        font-weight: bold;
+        color: $white-color;
+      }
+      &__icons {
+        font-weight: normal;
+        display: flex;
+        margin-left: 5px; 
+        float: right;
+        list-style: none;
+        a{
+        color: $white-color;
+        }
+        &__new-group {
+          margin-left: 5px;
+        }
+      }
+    }
+  }
+  //サイド画面グループ表示
+  .chat-side__groups {
+    width: 300px;
+    background-color: #2f3e51;
+    height: calc(100vh - 100px);
+    margin: auto 0;
+    padding: 20px 20px 0;
+    .group{
+      height: 65px;
+      width: 300px;
+      color: $white-color;
+      font-weight: bold;
+      margin-bottom: 40px;
+      &__group-name {
+        font-size: 15px;
+        margin-bottom: 5px;
+      }
+      &__latest-message {
+        font-size: 11px;
+        margin-bottom: 40px;
+      }
+    }
+  }
+}
+//メイン画面
+.main-chat {
+  height: 100vh;
+  width: calc(100vw - 300px);
+  float: right;
+  //メイン画面ヘッダー
+  &__header {
+    background-color: $white-color;
+    height: 100px;
+    display: flex;
+    margin: 0 40px;
+    border-bottom: 1px #eeeeee;
+    justify-content: space-between;
+    &__left-box {
+      margin-top: 35px;
+      &__current-group {
+        color: #333333;
+        font-size: 20px;
+        margin-bottom: 15px;
+      }
+      &__member-list {
+        font-size: 12px;
+        color: #999999;
+        display: flex;
+        &__name {
+        }
+      }
+    }
+    &__edit-btn {
+      cursor: pointer;
+      width: 72px;
+      height: 40px;
+      line-height: 40px;
+      padding: 0 20px;
+      margin-top: 28px;
+      border: solid 1px $btn-color;
+      font-size: 16px;
+      a{
+        text-decoration: none;
+        color: $btn-color;
+      }
+    }
+  }
+  //メインチャット画面
+  .main-chat__main-view {
+    background-color: #fafafa;
+    height: calc(100vh - 100px - 90px);
+    &__message {
+      margin-left: 40px;
+      &__upper-info {
+        padding-top: 35px;
+        display: flex;
+        &__talker {
+        color: #333;
+        font-size: 16px;
+        font-weight: bold;
+        }
+        &__date {
+        color: #999;
+        font-size: 12px;
+        text-align: center;
+        margin-left: 10px;
+        }
+      }
+      &__text {
+        color: #434A54;
+        font-size: 14px;
+        margin-bottom: 46px;
+      }
+    }
+  }
+  //メインフッター
+  .main-chat__footer {
+    background-color: #d2d2d2;
+    height: 90px;
+    padding: 20px 40px;
+    &__form {
+      display: flex;
+      .input-box {
+        width: 100%;
+        display: flex;
+        position: relative;
+        &__text {
+          height: 50px;
+          width: 100%;
+          color: #434a54;
+          border-style: none;
+          padding: 0 40px 0 10px;
+        }
+        &__image {
+          cursor: pointer;
+          font-size: 1.3rem;
+          position: absolute;
+          top: 10px;
+          right: 10px;
+          &__file {
+            display: none;
+          }
+        }
+      }
+      .submit-btn {
+        width: 100px;
+        height: 50px;
+        padding: 0 30px;
+        margin-left: 15px;
+        background-color: $btn-color;
+        color: $white-color;
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,0 +1,52 @@
+.main-chat
+  .main-chat__header
+    .main-chat__header__left-box
+      .main-chat__header__left-box__current-group
+        jjjj
+      .main-chat__header__left-box__member-list
+        member:
+        .main-chat__header__left-box__member-list__name
+          oooo
+    .main-chat__header__edit-btn
+      = link_to 'Edit','#' 
+  .main-chat__main-view
+    .main-chat__main-view__message
+      .main-chat__main-view__message__upper-info
+        .main-chat__main-view__message__upper-info__talker
+          aaa
+        .main-chat__main-view__message__upper-info__date
+          2020/01/01(Wed)01:00:00
+      .main-chat__main-view__message__text
+        hello world
+    .main-chat__main-view__message
+      .main-chat__main-view__message__upper-info
+        .main-chat__main-view__message__upper-info__talker
+          aaa
+        .main-chat__main-view__message__upper-info__date
+          2020/01/01(Wed)01:00:00
+      .main-chat__main-view__message__text
+        hello world
+    .main-chat__main-view__message
+      .main-chat__main-view__message__upper-info
+        .main-chat__main-view__message__upper-info__talker
+          aaa
+        .main-chat__main-view__message__upper-info__date
+          2020/01/01(Wed)01:00:00
+      .main-chat__main-view__message__text
+        hello world
+    .main-chat__main-view__message
+      .main-chat__main-view__message__upper-info
+        .main-chat__main-view__message__upper-info__talker
+          aaa
+        .main-chat__main-view__message__upper-info__date
+          2020/01/01(Wed)01:00:00
+      .main-chat__main-view__message__text
+        hello world
+  .main-chat__footer
+    %form.main-chat__footer__form
+      .input-box
+        %input{type: "text", class: "input-box__text", placeholder: "type a message"}
+        %label{class: "input-box__image"}
+          = icon('fas', 'image')
+          %input{type: "file", class: "input-box__image__file"}
+      %input{type: "submit", class: "submit-btn"}

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -1,0 +1,29 @@
+.chat-side
+  .chat-side__header
+    .chat-side__header__box
+      .chat-side__header__box__user-name
+        you
+      .chat-side__header__box__icons
+        .chat-side__header__box__icons__edit-user
+        = link_to "#" do
+          =icon('fas', 'edit')
+        .chat-side__header__box__icons__new-group
+        = link_to "#" do
+          =icon('fas', 'cog')
+  .chat-side__groups
+    .group__group-name
+      xxxxxx
+    .group__latest-message
+      まだありません
+    .group__group-name
+      xxxxxx
+    .group__latest-message
+      まだありません
+    .group__group-name
+      xxxxxx
+    .group__latest-message
+      まだありません
+    .group__group-name
+      xxxxxx
+    .group__latest-message
+      まだありません


### PR DESCRIPTION
#What
chat-spaceのメインページであるチャットページのフロント画面の実装。
記述方式はhaml、sass。
hamlに関してはメイン画面の_main_chat.html.haml、サイド画面の_side_bar.html.hamlに分けて作成。

#Why
chat-space制作にあたり、メイン画面であるチャットページの作成は必須となるため。

<img width="1440" alt="chat-space_mainviewchapter0106" src="https://user-images.githubusercontent.com/59186095/71791379-18e39c00-3078-11ea-8bfc-4b5a241466c7.png">

