### PR TITLE
チャット自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,5 @@
 $(function(){ 
+  last_message_id = $('.message:last').data("message-id");
   function buildHTML(message){
    if ( message.image ) {
      var html =
@@ -44,29 +45,56 @@ $(function(){
    };
  }
  
-$('#new_message').on('submit', function(e){
- e.preventDefault();
- var formData = new FormData(this);
- var url = $(this).attr('action')
- $.ajax({
-   url: url,
-   type: "POST",
-   data: formData,
-   dataType: 'json',
-   processData: false,
-   contentType: false
- })
-  .always(function(){
-    $(".submit-btn").prop("disabled", false);
+  $('#new_message').on('submit', function(e){
+  e.preventDefault();
+  var formData = new FormData(this);
+  var url = $(this).attr('action')
+  $.ajax({
+    url: url,
+    type: "POST",
+    data: formData,
+    dataType: 'json',
+    processData: false,
+    contentType: false
   })
-  .done(function(data){
-    var html = buildHTML(data);
-    $('.messages').append(html);
-    $('form')[0].reset();
-    $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+    .always(function(){
+      $(".submit-btn").prop("disabled", false);
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('form')[0].reset();
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+    })
+    .fail(function() {
+      alert('メッセージ送信に失敗しました');
+    });
   })
-  .fail(function() {
-    alert('メッセージ送信に失敗しました');
-  });
-})
+  var reloadMessages = function() {
+    var last_message_id = $(".main-chat__main-view:last").data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+      }
+    })
+    .fail(function() {
+      alert('自動更新に失敗しました');
+    })
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -69,6 +69,7 @@ $btn-color: #38aef0;
     }
   }
 }
+
 //メイン画面
 .main-chat {
   height: 100vh;

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -48,6 +48,7 @@ $btn-color: #38aef0;
     height: calc(100vh - 100px);
     margin: auto 0;
     padding: 20px 20px 0;
+    overflow: scroll;
     .group{
       height: 65px;
       width: 300px;
@@ -120,6 +121,7 @@ $btn-color: #38aef0;
     overflow: scroll;
     .main-chat__main-view {
       box-sizing: border-box;
+      overflow: scroll;
       &__message {
         margin-left: 40px;
         &__upper-info {

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-chat__main-view
+.main-chat__main-view{data: {message: {id: message.id}}}
   .main-chat__main-view__message
     .main-chat__main-view__message__upper-info
       .main-chat__main-view__message__upper-info__talker

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name  @message.user.name
+json.id         @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
chat-spaceアプリケーションで最新のチャットを自動的に更新できるように実装する。
#Why
現実装では投稿者以外のユーザーでは、リアルタイムでデータが反映されないため、
相手からのメッセージが自動でブラウザに反映されるようにし、
リロードしなくても相手からのメッセージが表示されるようにするため。

[![Image from Gyazo](https://i.gyazo.com/cd8bce5eed7d25c4680f323c11ed46aa.gif)](https://gyazo.com/cd8bce5eed7d25c4680f323c11ed46aa)